### PR TITLE
report connection as failed even in silent mode

### DIFF
--- a/lib/DB.mssql.js
+++ b/lib/DB.mssql.js
@@ -101,8 +101,8 @@ DBdriver.prototype.getPooledConnection = function (dbconfig, onInitialized, numR
       _this.platform.Log.error('MSSQL Pool Error: ' + err.toString(), { source: 'database' });
     });
     mspool.con.connect(function (err) {
-      if (err && !_this.silent){
-        _this.platform.Log('MSSQL Pool Error: ' + err.toString(), { source: 'database' });
+      if (err){
+        if (!_this.silent) _this.platform.Log('MSSQL Pool Error: ' + err.toString(), { source: 'database' });
         if(onFail) return onFail(err);
       }
       else {


### PR DESCRIPTION
Failed connections were incorrectly marked as connected, causing the application to think it had a valid connection, when it should have tried to create a new one.